### PR TITLE
Renew CommonLog

### DIFF
--- a/cmn-clib/cmn-clib.vcxproj
+++ b/cmn-clib/cmn-clib.vcxproj
@@ -166,6 +166,7 @@
     <ClCompile Include="src\CommonFile\CommonFile.c" />
     <ClCompile Include="src\CommonLog\CommonLog.c" />
     <ClCompile Include="src\CommonLog\CommonLogEx.c" />
+    <ClCompile Include="src\CommonLog\CommonLogMessage.c" />
     <ClCompile Include="src\CommonNet\CommonNetHttp.c" />
     <ClCompile Include="src\CommonNet\CommonNetSocket.c" />
     <ClCompile Include="src\CommonString\CommonString.c" />

--- a/cmn-clib/cmn-clib.vcxproj.filters
+++ b/cmn-clib/cmn-clib.vcxproj.filters
@@ -137,5 +137,8 @@
     <ClCompile Include="test\src\test_main.c">
       <Filter>ソース ファイル\test-src</Filter>
     </ClCompile>
+    <ClCompile Include="src\CommonLog\CommonLogMessage.c">
+      <Filter>ソース ファイル</Filter>
+    </ClCompile>
   </ItemGroup>
 </Project>

--- a/cmn-clib/inc/cmnclib/Common.h
+++ b/cmn-clib/inc/cmnclib/Common.h
@@ -14,6 +14,11 @@
 
 #include <stddef.h>
 
+/* パフォーマンス優先設定 */
+/*
+#define CMN_CLIB_HI_PERFORMANCE 1
+*/
+
 /* 真偽値 */
 #ifndef True
   #define True      1  /**< 真 */

--- a/cmn-clib/inc/cmnclib/CommonLog.h
+++ b/cmn-clib/inc/cmnclib/CommonLog.h
@@ -12,7 +12,10 @@
 #ifndef _COMMON_LOG_H
 #define _COMMON_LOG_H
 
+#include <time.h>
+
 #include "cmnclib/Common.h"
+#include "cmnclib/CommonThread.h"
 
 
 /** ログメッセージ格納構造体 */
@@ -27,45 +30,69 @@ typedef struct tag_CmnLogEx {
 	int level;				/**< ログ出力レベル       */
 	char *file;				/**< ログ出力ファイル     */
 	CmnLogMessage *list;	/**< ログメッセージリスト */
+	CmnThreadMutex* mutex;	/**< ログ出力処理をスレッドセーフにするためのミューテックス */
 } CmnLogEx;
 
 /** ログ出力レベル */
-enum {
+typedef enum {
 	CMN_LOG_LEVEL_NOTHING,     /**< 沈黙レベル（全てのログを出力しない） */
 	CMN_LOG_LEVEL_ERROR,       /**< エラーレベル（ERRORで指定されたログを出力） */
 	CMN_LOG_LEVEL_WARN,        /**< 警告レベル（ERROR/WARNで指定されたログを出力） */
 	CMN_LOG_LEVEL_INFO,        /**< 通知レベル（ERROR/WARN/INFOで指定されたログを出力） */
-	CMN_LOG_LEVEL_DEBUG,       /**< デバッグレベル（全てのログを出力） */
-	CMN_LOG_LEVEL_MAX = CMN_LOG_LEVEL_DEBUG  /**< ログレベルに指定できる最大値 */
-};
+	CMN_LOG_LEVEL_DEBUG,       /**< デバッグレベル（ERROR/WARN/INFO/DEBUGで指定されたログを出力） */
+	CMN_LOG_LEVEL_TRACE,       /**< トレースレベル（全てのログを出力） */
+	CMN_LOG_LEVEL_MAX = CMN_LOG_LEVEL_TRACE  /**< ログレベルに指定できる最大値 */
+} CMN_LOG_LEVEL;
 
 /* --- CommonLog.c --- */
 /* 標準ログ出力関数初期化処理 */
-D_EXTERN int CmnLog_Init(const char *log_file, int level);
+D_EXTERN int CmnLog_Init(const char* logFile, CMN_LOG_LEVEL level, const char* msgFile);
 /* 標準ログ出力共通関数終了処理 */
 D_EXTERN void CmnLog_End();
-/* 標準ログ出力 */
+/* 標準ログ出力（メッセージ指定） */
 D_EXTERN void CmnLog_Put(int level, const char *msgCode, ...);
-/* ログメッセージ定義ファイル読み込み */
-D_EXTERN CmnLogMessage* _CmnLogMessage_Create(const char *msgFile);
-/* ログメッセージリスト解放処理 */
-D_EXTERN void _CmnLogMessage_Free(CmnLogMessage *list);
-/* ログメッセージ取得関数 */
-D_EXTERN int _CmnLogMessage_Get(CmnLogMessage *list, const char *msg_code, CmnLogMessage *msg);
+/* 標準ログ出力（メッセージコード指定） */
+D_EXTERN void CmnLog_PutByCode(CmnLogEx* log, CMN_LOG_LEVEL level, const char* msgCode, ...);
+/* cmn-clibの内部ログ出力設定 */
+D_EXTERN void CmnLog_InitCmnClibLog(CmnLogEx *log, CMN_LOG_LEVEL level);
+/* cmn-clibの内部ログ出力終了 */
+D_EXTERN void CmnLog_EndCmnClibLog();
+/* cmn-clibの内部ログ出力 */
+D_EXTERN void CmnLog_PutCmnClibLog(CMN_LOG_LEVEL level, const char* msgCode, ...);
 
 /* --- CommonLogEx.c --- */
 /* 拡張ログ出力関数初期化処理 */
-D_EXTERN CmnLogEx *CmnLogEx_Init(const char *msgFile, int level, const char *file);
+D_EXTERN CmnLogEx* CmnLogEx_Create(const char* logFile, CMN_LOG_LEVEL level, const char* msgFile);
 /* 拡張ログ出力共通関数終了処理 */
-D_EXTERN void CmnLogEx_End(CmnLogEx *log);
-/* 拡張ログ出力 */
-D_EXTERN void CmnLogEx_Put(CmnLogEx *log, int level, const char *msgCode, ...);
+D_EXTERN void CmnLogEx_Free(CmnLogEx *log);
+/* 拡張ログ出力（メッセージ指定） */
+D_EXTERN void CmnLogEx_Put(CmnLogEx* log, CMN_LOG_LEVEL level, const char* msg, ...);
+/* 拡張ログ出力（メッセージコード指定） */
+D_EXTERN void CmnLogEx_PutByCode(CmnLogEx* log, CMN_LOG_LEVEL level, const char* msgCode, ...);
+/* 拡張ログ出力（ログ出力共通） */
+D_EXTERN void cmnLogEx_PutLog(CmnLogEx* log, CMN_LOG_LEVEL level, const char* msg, va_list args);
 
-/* ラッパーマクロ */
-#define CMNLOG_DEBUG(code, ...) CmnLog_Put(CMN_LOG_LEVEL_DEBUG, (code), __VA_ARGS__)
-#define CMNLOG_INFO(code, ...) CmnLog_Put(CMN_LOG_LEVEL_INFO, (code), __VA_ARGS__)
-#define CMNLOG_WARN(code, ...) CmnLog_Put(CMN_LOG_LEVEL_WARN, (code), __VA_ARGS__)
-#define CMNLOG_ERROR(code, ...) CmnLog_Put(CMN_LOG_LEVEL_ERROR, (code), __VA_ARGS__)
+/* --- CommonLogMessage.c --- */
+/* ログメッセージ定義ファイル読み込み */
+D_EXTERN CmnLogMessage* CmnLogMessage_Create(const char* msgFile);
+/* ログメッセージリスト解放処理 */
+D_EXTERN void CmnLogMessage_Free(CmnLogMessage* list);
+/* ログメッセージ取得関数 */
+D_EXTERN int CmnLogMessage_Get(CmnLogMessage* list, const char* msg_code, CmnLogMessage* msg);
+
+/* cmn-clib内部ログ出力ラッパーマクロ */
+#ifdef CMN_CLIB_HI_PERFORMANCE
+	#define CMNLOG_TRACE_START()
+	#define CMNLOG_TRACE_END()
+#else
+	#define CMNLOG_TRACE_START() clock_t cmnlogtrace_stclock=clock();CmnLog_PutCmnClibLog(CMN_LOG_LEVEL_TRACE, "START %s", __func__)
+	#define CMNLOG_TRACE_END() CmnLog_PutCmnClibLog(CMN_LOG_LEVEL_TRACE, "END %s(clocks=%d)", __func__, clock() - cmnlogtrace_stclock)
+#endif
+#define CMNLOG_TRACE(msg, ...) CmnLog_PutCmnClibLog(CMN_LOG_LEVEL_TRACE, (msg), __VA_ARGS__)
+#define CMNLOG_DEBUG(msg, ...) CmnLog_PutCmnClibLog(CMN_LOG_LEVEL_DEBUG, (msg), __VA_ARGS__)
+#define CMNLOG_INFO(msg, ...) CmnLog_PutCmnClibLog(CMN_LOG_LEVEL_INFO, (msg), __VA_ARGS__)
+#define CMNLOG_WARN(msg, ...) CmnLog_PutCmnClibLog(CMN_LOG_LEVEL_WARN, (msg), __VA_ARGS__)
+#define CMNLOG_ERROR(msg, ...) CmnLog_PutCmnClibLog(CMN_LOG_LEVEL_ERROR, (msg), __VA_ARGS__)
 
 #endif /* _COMMON_LOG_H */
 

--- a/cmn-clib/readme.txt
+++ b/cmn-clib/readme.txt
@@ -1,4 +1,4 @@
-cmn-clibのビルド方法や使い方、その他メモなどa
+cmn-clibのビルド方法や使い方、その他メモなど
 
 ■プロジェクト構成
 	・inc			# ヘッダーファイル格納場所。ヘッダーファイル名はソースファイルのディレクトリ名と同じ
@@ -34,6 +34,9 @@ cmn-clibのビルド方法や使い方、その他メモなどa
 		$ cd プロジェクトフォルダ
 		$ make
 
+	＜挙動を変えるマクロ＞
+		Common.h：CMN_CLIB_HI_PERFORMANCE　　defineされているとトレースログの省略等を行ったハイパフォーマンスモードでビルドする。
+
 ■テスト実施方法
 	＜Windows＞
 		test_mainを実行
@@ -41,8 +44,7 @@ cmn-clibのビルド方法や使い方、その他メモなどa
 		・テストビルド
 			$ cd プロジェクトフォルダ
 			$ make
-			$ cd build
-			$ ./test_main
+			$ build/test_main
 
 ■cmn-clibの利用方法（リンク方法）
 	//TODO
@@ -75,7 +77,8 @@ cmn-clibのビルド方法や使い方、その他メモなどa
 		例：CmnDataList_Create
 		　　CmnDataList_GetFirst
 		　　
-		※非公開関数はアンダーバーで始まる。
+		※非公開関数は先頭小文字で始まる。
+		　cmnLogEx_PutLog
 
 	＜定数マクロ名＞
 		全て大文字のアンダーバー区切り

--- a/cmn-clib/src/CommonConf/CommonConf.c
+++ b/cmn-clib/src/CommonConf/CommonConf.c
@@ -12,6 +12,7 @@
 
 #include"cmnclib/Common.h"
 #include"cmnclib/CommonConf.h"
+#include"cmnclib/CommonLog.h"
 
 /**
  * @brief 環境変数取得
@@ -28,13 +29,17 @@
 int CmnConf_GetEnv(char *buf, const char *envName)
 {
 	char *env;		/* 取得した環境変数の値 */
+	CMNLOG_TRACE_START();
 
 	env = getenv(envName);
 	if(env == NULL) {
+		CMNLOG_TRACE_END();
 		return False;
 	}
 
 	strcpy(buf, env);
+
+	CMNLOG_TRACE_END();
 	return True;
 }
 

--- a/cmn-clib/src/CommonConf/CommonConfProperty.c
+++ b/cmn-clib/src/CommonConf/CommonConfProperty.c
@@ -32,6 +32,7 @@
 #include"cmnclib/Common.h"
 #include"cmnclib/CommonConf.h"
 #include"cmnclib/CommonString.h"
+#include"cmnclib/CommonLog.h"
 
 #define PROP_BUF_SIZE  4096		/* プロパティファイル１行の最大文字数  */
 #define COMMENT_CHAR   '#'		/* コメント識別文字                    */
@@ -67,9 +68,11 @@ CmnConfProperty *CmnConfProperty_Load(const char *file)
 	FILE *prop_fp;
 	CmnConfProperty *list = NULL;
 	CmnConfProperty *tmp;
+	CMNLOG_TRACE_START();
 
 	prop_fp = fopen(file, "r");
 	if (prop_fp == NULL) {
+		CMNLOG_TRACE_END();
 		return NULL;
 	}
 
@@ -109,6 +112,9 @@ CmnConfProperty *CmnConfProperty_Load(const char *file)
 		/* 最初のリストを作成 */
 		if (list == NULL) {
 			list = (CmnConfProperty *)calloc(1, sizeof(CmnConfProperty));
+			if (list == NULL) {
+				return NULL;
+			}
 			list->name  = name_buf;
 			list->value = value_buf;
 			list->next  = NULL;
@@ -126,6 +132,8 @@ CmnConfProperty *CmnConfProperty_Load(const char *file)
 		}
 	}
 	fclose(prop_fp);
+
+	CMNLOG_TRACE_END();
 	return list;
 }
 
@@ -142,8 +150,10 @@ void CmnConfProperty_Free(CmnConfProperty *list)
 {
 	CmnConfProperty *p;
 	CmnConfProperty *tmp;
+	CMNLOG_TRACE_START();
 
 	if (list == NULL) {
+		CMNLOG_TRACE_END();
 		return;
 	}
 
@@ -154,6 +164,7 @@ void CmnConfProperty_Free(CmnConfProperty *list)
 		free(p->value);
 		free(p);
 	}
+	CMNLOG_TRACE_END();
 }
 
 
@@ -169,11 +180,14 @@ void CmnConfProperty_Free(CmnConfProperty *list)
  */
 char *CmnConfProperty_GetValue(const CmnConfProperty *list, const char *name )
 {
+	CMNLOG_TRACE_START();
 	for (; list; list = list->next) {
 		if (strcmp(list->name, name) == 0) {
+			CMNLOG_TRACE_END();
 			return list->value;
 		}
 	}
+	CMNLOG_TRACE_END();
 	return NULL;
 }
 

--- a/cmn-clib/src/CommonData/CommonDataBuffer.c
+++ b/cmn-clib/src/CommonData/CommonDataBuffer.c
@@ -10,6 +10,7 @@
 #include<string.h>
 
 #include "cmnclib/CommonData.h"
+#include "cmnclib/CommonLog.h"
 
 static const size_t DEFAULT_BUFFER_SIZE = 4096;
 
@@ -23,8 +24,12 @@ static const size_t DEFAULT_BUFFER_SIZE = 4096;
  */
 CmnDataBuffer* CmnDataBuffer_Create(size_t bufSize)
 {
-	CmnDataBuffer *ret = malloc(sizeof(CmnDataBuffer));
+	CmnDataBuffer *ret;
+	CMNLOG_TRACE_START();
+
+	ret = malloc(sizeof(CmnDataBuffer));
 	if (ret == NULL) {
+		CMNLOG_TRACE_END();
 		return NULL;
 	}
 
@@ -32,10 +37,13 @@ CmnDataBuffer* CmnDataBuffer_Create(size_t bufSize)
 		bufSize = DEFAULT_BUFFER_SIZE;
 	}
 	if ((ret->data = malloc(bufSize)) == NULL) {
+		CMNLOG_TRACE_END();
 		return NULL;
 	}
 	ret->bufSize = bufSize;
 	ret->size = 0;
+
+	CMNLOG_TRACE_END();
 	return ret;
 }
 
@@ -54,6 +62,7 @@ int CmnDataBuffer_Append(CmnDataBuffer *buf, const void *data, size_t len)
 	void *buftmp;
 	size_t oldBufSize = buf->bufSize;
 	size_t newBufSize = buf->size + len;
+	CMNLOG_TRACE_START();
 
 	/* 領域が不足する場合は拡張 */
 	if (oldBufSize < newBufSize) {
@@ -65,6 +74,7 @@ int CmnDataBuffer_Append(CmnDataBuffer *buf, const void *data, size_t len)
 
 		buftmp = realloc(buf->data, newBufSize);
 		if (buftmp == NULL) {
+			CMNLOG_TRACE_END();
 			return -1;
 		}
 		buf->data = buftmp;
@@ -75,6 +85,7 @@ int CmnDataBuffer_Append(CmnDataBuffer *buf, const void *data, size_t len)
 	memcpy(((char*)buf->data) + buf->size, data, len);
 	buf->size += len;
 
+	CMNLOG_TRACE_END();
 	return 0;
 }
 
@@ -94,6 +105,7 @@ int CmnDataBuffer_Set(CmnDataBuffer *buf, const void *data, size_t len)
 	size_t oldBufSize = buf->bufSize;
 	size_t newBufSize = len;
 	int resize = False;
+	CMNLOG_TRACE_START();
 
 	/* 領域が不足する場合は拡張 */
 	if (oldBufSize < newBufSize) {
@@ -113,6 +125,7 @@ int CmnDataBuffer_Set(CmnDataBuffer *buf, const void *data, size_t len)
 	if (resize) {
 		buftmp = realloc(buf->data, newBufSize);
 		if (buftmp == NULL) {
+			CMNLOG_TRACE_END();
 			return -1;
 		}
 		buf->data = buftmp;
@@ -123,6 +136,7 @@ int CmnDataBuffer_Set(CmnDataBuffer *buf, const void *data, size_t len)
 	memcpy(buf->data, data, len);
 	buf->size = len;
 
+	CMNLOG_TRACE_END();
 	return 0;
 }
 
@@ -136,10 +150,12 @@ int CmnDataBuffer_Set(CmnDataBuffer *buf, const void *data, size_t len)
  */
 void CmnDataBuffer_Delete(CmnDataBuffer *buf, size_t len)
 {
+	CMNLOG_TRACE_START();
 	if (buf->size < len) {
 		len = buf->size;
 	}
 	buf->size -=len;
+	CMNLOG_TRACE_END();
 }
 
 /**
@@ -151,7 +167,9 @@ void CmnDataBuffer_Delete(CmnDataBuffer *buf, size_t len)
  */
 void CmnDataBuffer_Free(CmnDataBuffer *buf)
 {
+	CMNLOG_TRACE_START();
 	free(buf->data);
 	free(buf);
+	CMNLOG_TRACE_END();
 }
 

--- a/cmn-clib/src/CommonData/CommonDataList.c
+++ b/cmn-clib/src/CommonData/CommonDataList.c
@@ -12,6 +12,7 @@
 
 #include"cmnclib/Common.h"
 #include"cmnclib/CommonData.h"
+#include"cmnclib/CommonLog.h"
 
 
 /**
@@ -25,11 +26,15 @@
 CmnDataList *CmnDataList_Create()
 {
 	CmnDataList *list;
+	CMNLOG_TRACE_START();
+
 	list = malloc(sizeof(CmnDataList));
 	if (list != NULL) {
 		list->first = NULL;
 		list->size  = 0;
 	}
+
+	CMNLOG_TRACE_END();
 	return list;
 }
 
@@ -56,8 +61,12 @@ void CmnDataList_Free(CmnDataList *list, void *method)
 {
 	CmnDataListItem *item, *tmp;
 	void (*freeMethod)() = method;
+	CMNLOG_TRACE_START();
 
-	if (list == NULL) return;
+	if (list == NULL) {
+		CMNLOG_TRACE_END();
+		return;
+	}
 
 	for (item = list->first; item; item = tmp) {
 		tmp = item->next;
@@ -67,6 +76,8 @@ void CmnDataList_Free(CmnDataList *list, void *method)
 		free(item);
 	}
 	free(list);
+
+	CMNLOG_TRACE_END();
 }
 
 
@@ -83,9 +94,17 @@ void CmnDataList_Free(CmnDataList *list, void *method)
 void CmnDataList_Add(CmnDataList *list, void *data)
 {
 	CmnDataListItem *item, *p, *tmp;
+	CMNLOG_TRACE_START();
 
-	if (list == NULL) return;
-	if ((item = malloc(sizeof(CmnDataListItem))) == NULL) return;
+	if (list == NULL) {
+		CMNLOG_TRACE_END();
+		return;
+	}
+
+	if ((item = malloc(sizeof(CmnDataListItem))) == NULL) {
+		CMNLOG_TRACE_END();
+		return;
+	}
 	item->data = data;
 	item->next = NULL;
 
@@ -100,6 +119,8 @@ void CmnDataList_Add(CmnDataList *list, void *data)
 		tmp->next = item;
 	}
 	list->size++ ;
+
+	CMNLOG_TRACE_END();
 }
 
 
@@ -117,12 +138,17 @@ void *CmnDataList_Get(CmnDataList *list, int index)
 {
 	CmnDataListItem *item;
 	int i;
+	CMNLOG_TRACE_START();
 
-	if (list == NULL) return NULL;
+	if (list == NULL) {
+		CMNLOG_TRACE_END();
+		return NULL;
+	}
 
 	item = list->first;
 	for (i = 0; i < index; i++) {
 		if (item == NULL) {
+			CMNLOG_TRACE_END();
 			return NULL;
 		}
 		else {
@@ -130,6 +156,7 @@ void *CmnDataList_Get(CmnDataList *list, int index)
 		}
 	}
 
+	CMNLOG_TRACE_END();
 	return (item) ? item->data : NULL ;
 }
 

--- a/cmn-clib/src/CommonData/CommonDataStack.c
+++ b/cmn-clib/src/CommonData/CommonDataStack.c
@@ -9,6 +9,7 @@
 #include<stdlib.h>
 
 #include "cmnclib/CommonData.h"
+#include"cmnclib/CommonLog.h"
 
 /**
  * @brief スタック作成
@@ -21,10 +22,14 @@
 CmnDataStack* CmnDataStack_Create()
 {
 	CmnDataStack *ret;
+	CMNLOG_TRACE_START();
+
 	ret = malloc(sizeof(CmnDataStack));
 	ret->first = NULL;
 	ret->last = NULL;
 	ret->size = 0L;
+
+	CMNLOG_TRACE_END();
 	return ret;
 }
 
@@ -50,7 +55,12 @@ void CmnDataStack_Free(CmnDataStack *stack, void *method)
 {
 	CmnDataStackItem *current;
 	void (*freeMethod)() = method;
-	if (stack == NULL) return;
+	CMNLOG_TRACE_START();
+
+	if (stack == NULL) {
+		CMNLOG_TRACE_END();
+		return;
+	}
 
 	current = stack->first;
 	while (current != NULL) {
@@ -63,6 +73,7 @@ void CmnDataStack_Free(CmnDataStack *stack, void *method)
 	}
 
 	free(stack);
+	CMNLOG_TRACE_END();
 }
 
 /**
@@ -78,7 +89,12 @@ void CmnDataStack_Free(CmnDataStack *stack, void *method)
 void CmnDataStack_Push(CmnDataStack *stack, void *data)
 {
 	CmnDataStackItem *item;
-	if (stack == NULL) return;
+	CMNLOG_TRACE_START();
+
+	if (stack == NULL) {
+		CMNLOG_TRACE_END();
+		return;
+	}
 
 	item = malloc(sizeof(CmnDataStackItem));
 	item->prev = stack->last;
@@ -94,6 +110,8 @@ void CmnDataStack_Push(CmnDataStack *stack, void *data)
 		stack->last = item;
 	}
 	stack->size++;
+
+	CMNLOG_TRACE_END();
 }
 
 /**
@@ -108,7 +126,10 @@ void CmnDataStack_Push(CmnDataStack *stack, void *data)
 void* CmnDataStack_Pop(CmnDataStack *stack)
 {
 	CmnDataStackItem *item = NULL;
+	CMNLOG_TRACE_START();
+
 	if (stack == NULL || stack->size == 0) {
+		CMNLOG_TRACE_END();
 		return NULL;
 	}
 	item = stack->last;
@@ -118,6 +139,8 @@ void* CmnDataStack_Pop(CmnDataStack *stack)
 
 	char *ret = item->data;
 	free(item);
+
+	CMNLOG_TRACE_END();
 	return ret;
 }
 

--- a/cmn-clib/src/CommonFile/CommonFile.c
+++ b/cmn-clib/src/CommonFile/CommonFile.c
@@ -12,6 +12,7 @@
 #include "cmnclib/Common.h"
 #include "cmnclib/CommonFile.h"
 #include "cmnclib/CommonData.h"
+#include"cmnclib/CommonLog.h"
 
 #if IS_PRATFORM_WINDOWS()
 #include<windows.h>
@@ -39,18 +40,24 @@ static CmnDataList* ListForLinux(const char *path, CmnDataList *list);
 char* CmnFile_ReadAllText(const char *filePath)
 {
 	char *ret;
-	CmnDataBuffer *buf = CmnFile_ReadAll(filePath);
+	CmnDataBuffer *buf;
+	CMNLOG_TRACE_START();
+
+	buf = CmnFile_ReadAll(filePath);
 	if (buf == NULL) {
+		CMNLOG_TRACE_END();
 		return NULL;
 	}
 
 	if ((ret = malloc(buf->size + 1)) == NULL) {
+		CMNLOG_TRACE_END();
 		return NULL;
 	}
 	strncpy(ret, buf->data, buf->size);
 	ret[buf->size] = '\0';
 	CmnDataBuffer_Free(buf);
 
+	CMNLOG_TRACE_END();
 	return ret;
 }
 
@@ -69,25 +76,30 @@ CmnDataBuffer* CmnFile_ReadAll(const char *filePath)
 	CmnDataBuffer *buf;
 	char tmp[BUF_SIZE];
 	int readLen;
+	CMNLOG_TRACE_START();
 
 	if ((fp = fopen(filePath, "rb")) == NULL) {
+		CMNLOG_TRACE_END();
 		return NULL;
 	}
 
 	if ((buf = CmnDataBuffer_Create(0)) == NULL) {
 		fclose(fp);
+		CMNLOG_TRACE_END();
 		return NULL;
 	}
 
 	while ((readLen = fread(tmp, sizeof(tmp[0]), BUF_SIZE, fp)) > 0) {
 		if (CmnDataBuffer_Append(buf, tmp, readLen) != 0) {
 			CmnDataBuffer_Free(buf);
+			CMNLOG_TRACE_END();
 			return NULL;
 		}
 
 	}
 
 	fclose(fp);
+	CMNLOG_TRACE_END();
 	return buf;
 }
 
@@ -99,7 +111,10 @@ CmnDataBuffer* CmnFile_ReadAll(const char *filePath)
  */
 int CmnFile_WriteNew(const char *filePath, void *data, size_t len)
 {
+	CMNLOG_TRACE_START();
+
 	//TODO
+	CMNLOG_TRACE_END();
 	return 0;
 }
 
@@ -111,7 +126,10 @@ int CmnFile_WriteNew(const char *filePath, void *data, size_t len)
  */
 int CmnFile_WriteHead(const char *filePath, void *data, size_t len)
 {
+	CMNLOG_TRACE_START();
+
 	//TODO
+	CMNLOG_TRACE_END();
 	return 0;
 }
 
@@ -123,7 +141,10 @@ int CmnFile_WriteHead(const char *filePath, void *data, size_t len)
  */
 int CmnFile_WriteTail(const char *filePath, void *data, size_t len)
 {
+	CMNLOG_TRACE_START();
+
 	//TODO
+	CMNLOG_TRACE_END();
 	return 0;
 }
 
@@ -135,16 +156,23 @@ int CmnFile_WriteTail(const char *filePath, void *data, size_t len)
  */
 CmnDataList* CmnFile_List(const char *path, CmnDataList *list, CHARSET pathCharset)
 {
+	CMNLOG_TRACE_START();
+	CmnDataList *ret;
+
 #if IS_PRATFORM_WINDOWS()
-	return ListForWindows(path, list, pathCharset);
+	ret = ListForWindows(path, list, pathCharset);
 #else
-	return ListForLinux(path, list);
+	ret = ListForLinux(path, list);
 #endif
+
+	CMNLOG_TRACE_END();
+	return ret;
 }
 
 char* CmnFileInfo_ToString(const CmnFileInfo *info, char *buf)
 {
 	char timeBuf[160];
+	CMNLOG_TRACE_START();
 
 	*buf = '\0';
 	sprintf(buf, "dir=%s, name=%s, size=%I64d, lastUpdateTime=[%s], isDirectory=%d, isFile=%d, isHiddenFile=%d, isSystemFile=%d, isSymbolicLink=%d",
@@ -157,6 +185,8 @@ char* CmnFileInfo_ToString(const CmnFileInfo *info, char *buf)
 			info->isHiddenFile,
 			info->isSystemFile,
 			info->isSymbolicLink);
+
+	CMNLOG_TRACE_END();
 	return buf;
 }
 
@@ -178,6 +208,8 @@ static CmnDataList* ListForWindows(const char *path, CmnDataList *list, CHARSET 
 	CmnFileInfo *info;
 	CmnTimeDateTime cmnTime;
 
+	CMNLOG_TRACE_START();
+
 	/* TODO:最後の文字がパス区切りなら除去 */
 
 	/* TODO:pathの存在確認して、存在しなければNULLリターン */
@@ -191,6 +223,7 @@ static CmnDataList* ListForWindows(const char *path, CmnDataList *list, CHARSET 
 	/* ファイル一覧を取得 */
 	hFind = FindFirstFileW(searchPathWide, &win32fd);
 	if (hFind == INVALID_HANDLE_VALUE) {
+		CMNLOG_TRACE_END();
 		return list;
 	}
 
@@ -233,6 +266,7 @@ static CmnDataList* ListForWindows(const char *path, CmnDataList *list, CHARSET 
 
 	FindClose(hFind);
 
+	CMNLOG_TRACE_END();
 	return list;
 }
 
@@ -243,7 +277,9 @@ static CmnDataList* ListForWindows(const char *path, CmnDataList *list, CHARSET 
 
 static CmnDataList* ListForLinux(const char *path, CmnDataList *list)
 {
+	CMNLOG_TRACE_START();
 	/* TODO */
+	CMNLOG_TRACE_END();
 	return NULL;
 }
 

--- a/cmn-clib/src/CommonLog/CommonLog.c
+++ b/cmn-clib/src/CommonLog/CommonLog.c
@@ -1,25 +1,29 @@
 /** @file *********************************************************************
  * @brief 標準ログ出力 共通関数
  *
- *  ログを標準出力に出力する。ログの出力形式はログメッセージ定義ファイルで定義できる。<BR>
- *  ログをファイルに出力する場合は、拡張ログ出力共通関数を使用すること。<BR>
+ *  プロセスの標準ログを出力する。ログの出力先や出力レベルはCmnLog_Initで指定する。
+ *  ログを別ファイルに出力したい場合は、拡張ログ出力共通関数を使用することで複数出力先にログを出し分けることが可能。<BR>
+ *  ログの出力形式はフリーフォーマットの他、ログメッセージ定義ファイルで定義することが可能。<BR>
+ *  ログ出力メッセージの書式にはprintf書式を使用可能。<BR>
  * <BR>
  *  ＜使用例＞<BR>
  * --- message.conf（メッセージログファイル） ---------------------<BR>
- * TEST01, テストログ%s<BR>
- * TEST02, テスト%d回目%s<BR>
+ * C001, テストログ%s<BR>
+ * C002, テスト%d回目%s<BR>
  * ----------------------------------------------------------------<BR>
  * <BR>
  * ・以下、ログ出力処理例<BR>
- * if ( ! CmnLog_Init("message.conf", CMN_LOG_LEVEL_DETAIL)) return ;<BR>
- * CmnLog_Put(CMN_LOG_LEVEL_DETAIL, "TEST01", "です");<BR>
- * CmnLog_Put(CMN_LOG_LEVEL_STANDARD, "TEST02", 1, "です");<BR>
- * CmnLog_Put(CMN_LOG_LEVEL_DEBUG, "TEST01", "です");<BR>
+ * if ( ! CmnLog_Init("message.conf", CMN_LOG_LEVEL_INFO)) return ;<BR>
+ * CmnLog_Put(CMN_LOG_LEVEL_INFO, "処理結果=%d, detail=%s", 100, 正常終了);
+ * CmnLog_PutByCode(CMN_LOG_LEVEL_INFO, "C001", "です");<BR>
+ * CmnLog_PutByCode(CMN_LOG_LEVEL_INFO, "C002", 1, "です");<BR>
+ * CmnLog_PutByCode(CMN_LOG_LEVEL_DEBUG, "C001", "です");<BR>
  * CmnLog_End();<BR>
  * <BR>
- * ・以下、出力例（CMN_LOG_LEVEL_DEGUBで指定したメッセージは出力されない）<BR>
- * YYYY/MM/DD CODE=TEST01 : テストログです<BR>
- * YYYY/MM/DD CODE=TEST01 : テスト1回目です<BR>
+ * ・以下、出力例（CMN_LOG_LEVEL_DEBUGで指定したメッセージは出力されない）<BR>
+ * YYYY/MM/DD HH:MM:SS [INFO] 処理結果=100, detail=正常終了
+ * YYYY/MM/DD HH:MM:SS [INFO] テストログです<BR>
+ * YYYY/MM/DD HH:MM:SS [INFO] テスト1回目です<BR>
  *
  * @author H.Kumagai
  * @date   2004-06-06
@@ -39,17 +43,23 @@
 #define PARSE_CHAR   ','
 #define COMMENT_CHAR '#'
 
-static CmnLogMessage *gList = NULL;    /* ログメッセージリスト先頭へのポインタ */
-static int gLevel;                     /* ログ出力レベル                       */
+static CmnLogEx *gLogEx = NULL;				/* 標準ログ */
+static CmnLogEx *gLogExCmnClib = NULL;		/* cmn-clib内部ログ */
+static CMN_LOG_LEVEL gLogLevelCmnClib = CMN_LOG_LEVEL_NOTHING;	/* cmn-clib内部ログ出力レベル */
 
 /**
  * @brief 標準ログ出力関数初期化処理
  *
- *  ログメッセージ定義ファイルを読み込む。<BR>
+ *  標準ログ出力の初期化を行う<BR>
  *  標準ログ出力関数を使用する前にこの関数をコールしなければならない。<BR>
  *  また、標準ログ出力関数の使用後（アプリケーション終了時）は、CmnLog_End関数をコールすること<BR>
- *  １つのアプリケーションでログ形式を複数使用する場合や、
- *  ログをファイルに出力する場合は、拡張ログ出力関数（CmnLog_InitEx）を使用すること。
+ *  １つのアプリケーションでログ形式を複数使用する場合は、拡張ログ出力関数（CmnLogEx_Create）を使用すること。
+ *
+ * @param logFile   (I)   ログを出力するファイルパスを指定する。<BR>
+ *                        NULLを指定した場合は標準出力にログを出力する。<BR>
+ *                        ファイルへの書き込みモードは、「追加書き込み」である。
+ *
+ * @param level     (I)   ログ出力レベル。<BR>
  *
  * @param msgFile   (I)   ログメッセージ定義ファイルへのパス<BR>
  *                        定義ファイルは、以下の構文に従わなければならない。
@@ -65,14 +75,6 @@ static int gLevel;                     /* ログ出力レベル                 
  *                        ERROR-01, エラー発生。XXの値は[%s]です。%d回目の処理でした。#ここもコメント<BR>
  *                        ↑メッセージコード,　　↑メッセージ
  *
- * @param level     (I)   ログ出力レベル。<BR>
- *                        以下のものから指定する。
- *                    <UL>
- *                      <LI>CMN_LOG_LEVEL_NOTHING  &nbsp;&nbsp; --沈黙レベル（全てのログを出力しない）</LI>
- *                      <LI>CMN_LOG_LEVEL_STANDARD &nbsp;&nbsp; --標準レベル（STANDARDで指定されたログを出力）</LI>
- *                      <LI>CMN_LOG_LEVEL_DETAIL   &nbsp;&nbsp; --詳細レベル（DETAILとSTANDARDで指定されたログを出力）</LI>
- *                      <LI>CMN_LOG_LEVEL_DEBUG    &nbsp;&nbsp; --デバッグレベル（全てのログを出力）</LI>
- *                    </UL>
  * @retval True  初期化処理成功
  * @retval False 初期化処理失敗（以下のような場合に失敗する）<BR>
  *                   msgFileのパスが不正な場合<BR>
@@ -80,22 +82,20 @@ static int gLevel;                     /* ログ出力レベル                 
  *                   levelに不正な値が設定された場合
  * @author H.Kumagai
  */
-int CmnLog_Init(const char *msgFile, int level)
+int CmnLog_Init(const char* logFile, CMN_LOG_LEVEL level, const char* msgFile)
 {
-	/* TODO:msgFile	にNULLが渡された場合はエラーにしないこと。（メッセージファイルなしでも手軽に使えるように） */
-
-	/* ログレベル設定 */
-	if (level > CMN_LOG_LEVEL_MAX) return False;
-	gLevel = level;
-
 	/* 2回の起動は認めない。正常に起動出来たとしてreturn */
-	if (gList) {
+	if (gLogEx) {
 		return True;
 	}
 
-	/* メッセージリストを取得 */
-	gList = _CmnLogMessage_Create(msgFile);
-	return gList ? True : False ;
+	/* LogExの初期化 */
+	gLogEx = CmnLogEx_Create(logFile, level, msgFile);
+	if (gLogEx == NULL) {
+		return False;
+	}
+
+	return True;
 }
 
 
@@ -109,191 +109,122 @@ int CmnLog_Init(const char *msgFile, int level)
  */
 void CmnLog_End()
 {
-	_CmnLogMessage_Free(gList);
-	gList = NULL;
+	CmnLogEx_Free(gLogEx);
+	gLogEx = NULL;
 }
 
 
 /**
  * @brief 標準ログ出力
  *
- *  ログを出力する。出力先はstdout。<BR>
+ *  ログを出力する。<BR>
  *  CmnLog_Init関数をコールする前に本関数をコールした場合は何も行わない。<BR>
  *  <ログ出力例><BR>
- *    yyyy/mm/dd[hh:mm:ss] CODE=メッセージコード : メッセージ本文
+ *    yyyy/mm/dd[hh:mm:ss] [level] メッセージ本文
  *
+ * @param level            (I) ログレベル。LoggerInitで指定されたログレベルと比較し、出力可否を決める。
+ * @param msg              (I) メッセージ文言
+ * @param ...              (I) メッセージ内に含まれる%sや%dの部分に対応する変数を指定する
+ * @author H.Kumagai
+ */
+void CmnLog_Put(int level, const char *msg, ...)
+{
+	va_list args;
+
+	if (gLogEx == NULL) {
+		return;
+	}
+
+	va_start(args, msg);
+	cmnLogEx_PutLog(gLogEx, level, msg, args);
+	va_end(args);
+}
+
+
+/**
+ * @brief 標準ログ出力
+ *
+ *  メッセージコードをもとにログを出力する。<BR>
+ *  <ログ出力例><BR>
+ *    yyyy/mm/dd[hh:mm:ss] [level] msgCodeに対応するメッセージ文言
+ *
+ * @param log              (I) 拡張ログ情報構造体へのポインタ（CmnLog_InitEx()関数の戻り値）
  * @param level            (I) ログレベル。LoggerInitで指定されたログレベルと比較し、出力可否を決める。
  * @param msgCode          (I) メッセージコード
  * @param ...              (I) メッセージ内に含まれる%sや%dの部分に対応する変数を指定する
  * @author H.Kumagai
+ * @note メッセージコードが存在しない場合は何も出力されない
  */
-void CmnLog_Put(int level, const char *msgCode, ...)
+void CmnLog_PutByCode(CmnLogEx* log, CMN_LOG_LEVEL level, const char* msgCode, ...)
 {
-	/* TODO:msgCode	にNULLが渡された場合はエラーにしないこと。（メッセージファイルなしでも手軽に使えるように） */
 	va_list args;
-	char str_date[CMN_TIME_FORMAT_SIZE_ALL];
-	char format[512];
 	CmnLogMessage msg;
 
-	if (gList == NULL) return ;
-
-	/* ログレベルチェック */
-	if (level > gLevel) return;
-
-	/* 書式フォーマットされた現在時刻文字列を取得 */
-	CmnTime_Format(CMN_TIME_FORMAT_ALL, str_date);
-
-	/* 出力メッセージを取得 */
-	if ( ! _CmnLogMessage_Get(gList, msgCode, &msg)) {
-		return ;
-	}
-
-	/* 時刻、メッセージコード部分を出力 */
-	sprintf(format, "%s CODE=%s : ", str_date, msg.code);
-	fprintf(stdout, format);
-
-	/* メッセージ本文を出力 */
-	va_start(args, msgCode);
-	vfprintf(stdout, strcat(msg.msg, "\n"), args);
-	va_end(args);
-
-}
-
-
-/**
- * @brief ログメッセージ定義ファイル読み込み
- *
- *  ログメッセージファイルの読み込みを行い、
- *  LogMessage構造体にデータを格納する。
- *
- * @param msgFile    (I)   ログメッセージ定義ファイルへのパス<BR>
- * @retval LogMessageへのポインタ 読み込み完了
- * @retval NULL False 読み込み失敗（以下のような場合に失敗する）<BR>
- *              fileが無効なポインタの場合<BR>
- *              メッセージ定義ファイルの文法が不正な場合<BR>
- * @author H.Kumagai
- * @note この関数は、ログ出力共通関数から使用される。外部からの使用は禁止。
- */
-CmnLogMessage *_CmnLogMessage_Create(const char *msgFile)
-{
-	FILE *fp;
-	CmnLogMessage *list = NULL;
-	CmnLogMessage *tmp;
-	char  buf[MSG_BUFSIZ];
-	char *code_pos;
-	char *code_buf;
-	char *msg_pos;
-	char *msg_buf;
-
-	fp = fopen(msgFile, "r");
-	if (fp == NULL) {
-		return NULL;
-	}
-
-	while (fgets(buf, MSG_BUFSIZ, fp)) {
-		/* コメントもしくは空行であれば無視 */
-		if(CmnString_Trim(buf)[0] == '\n' || CmnString_Trim(buf)[0] == COMMENT_CHAR) {
-			continue ;
-		}
-
-		/* コードとメッセージへのポインタを取得（同時に区切り文字を'\0'に変換） */
-		msg_pos = strchr(buf, PARSE_CHAR);
-		if (msg_pos == NULL) {
-			fclose(fp);
-			return NULL;
-		}
-		*msg_pos = '\0';
-		msg_pos++ ;
-		code_pos = buf;
-
-		/* 改行コードを除去 */
-		if (msg_pos[strlen(msg_pos) - 1] == '\n') {
-			msg_pos[strlen(msg_pos) - 1] = '\0';
-		}
-
-		/* コードとメッセージの領域を確保 */
-		code_buf = malloc(strlen(code_pos) + 1);
-		strcpy(code_buf, CmnString_Trim(code_pos));
-		msg_buf = malloc(strlen(msg_pos) + 1);
-		strcpy(msg_buf, CmnString_Trim(msg_pos));
-
-		/* 最初のリストを作成 */
-		if (list == NULL) {
-			list = (CmnLogMessage *)calloc(1, sizeof(CmnLogMessage));
-			list->code = code_buf;
-			list->msg  = msg_buf;
-			list->next = NULL;
-			tmp = list;
-		}
-		/* 2番目以降のリストを作成 */
-		else {
-			tmp->next = (CmnLogMessage *)calloc(1, sizeof(CmnLogMessage));
-			tmp = tmp->next;
-			tmp->code = code_buf;
-			tmp->msg  = msg_buf;
-			tmp->next = NULL;
-		}
-	}
-	fclose(fp);
-	return list;
-}
-
-
-/**
- * @brief ログメッセージリスト解放処理
- *
- *  ログメッセージリストのメモリ領域を解放する
- *
- * @param list    (I)   解放するログメッセージリストへのポインタ
- * @author H.Kumagai
- * @note この関数は、ログ出力共通関数から使用される。外部からの使用は禁止。
- */
-void _CmnLogMessage_Free(CmnLogMessage *list)
-{
-	CmnLogMessage *p;
-	CmnLogMessage *tmp;
-
-	if (list == NULL) {
+	if (gLogEx == NULL) {
 		return;
 	}
 
-	for (p = list; p; p = tmp) {
-		tmp = p->next;
-
-		free(p->code);
-		free(p->msg);
-		free(p);
+	/* 出力メッセージを取得 */
+	if (!CmnLogMessage_Get(log->list, msgCode, &msg)) {
+		return;
 	}
-}
 
+	/* メッセージ本文を出力 */
+	va_start(args, msgCode);
+	cmnLogEx_PutLog(log, level, msg.msg, args);
+	va_end(args);
+}
 
 /**
- * @brief ログメッセージ取得
- *
- *  メッセージコードに対応したメッセージコード文字列とメッセージ文字列を取得する
- *
- * @param list         (I) ログメッセージリスト
- * @param msg_code     (I) メッセージコード
- * @param msg          (O) LogMessage構造体へのポインタを指定する。<BR>
- *                         メッセージ取得成功時には、msg->codeとmsg->msgに値が格納される
- * @retval True 取得成功時
- * @retval False 取得失敗時（該当するメッセージコードが存在しない場合）
- * @author H.Kumagai
- * @note この関数は、ログ出力共通関数から使用される。外部からの使用は禁止。
+ * cmn-clib内部ログ出力設定。<br>
+ * この関数を実行するとcmn-clibの内部ログが指定したlogに出力される。
+ * @param log cmn-clib内部ログ出力先。NULLを指定した場合は標準ログとなる。
+ * @param level cmn-clib内部ログの出力レベル（log->levelより低いレベルのログを指定しても無効）
  */
-int _CmnLogMessage_Get(CmnLogMessage *list, const char *msg_code, CmnLogMessage *msg)
-{
-	CmnLogMessage *p;
-
-	if (list == NULL) return False;
-
-	for (p = list; p; p = p->next){
-		if (strcmp(p->code, msg_code) == EQUAL) {
-			msg->code = p->code;
-			msg->msg  = p->msg;
-			return True;
-		}
-	}
-	return False;
+void CmnLog_InitCmnClibLog(CmnLogEx *log, CMN_LOG_LEVEL level) {
+	gLogExCmnClib = log;
+	gLogLevelCmnClib = level;
 }
 
+/**
+ * cmn-clib内部ログ出力終了
+ */
+void CmnLog_EndCmnClibLog()
+{
+	gLogLevelCmnClib = CMN_LOG_LEVEL_NOTHING;
+}
+
+/**
+ * @brief cmn-clib内部ログ出力
+ *
+ *  cmn-clib内部ログを出力する。<BR>
+ *  CmnLog_InitCmnClibLog関数をコールする前に本関数をコールした場合は何も行わない。<BR>
+ *  この関数のラッパーマクロとして「CMNLOG_DEBUG」～「CMNLOG_ERROR」がある。<BR>
+ *  <ログ出力例><BR>
+ *    yyyy/mm/dd hh:mm:ss [level] メッセージ本文
+ *
+ * @param level            (I) ログレベル。CmnLog_InitCmnClibLogで指定されたログレベルと比較し、出力可否を決める。
+ * @param msg              (I) メッセージ文言
+ * @param ...              (I) メッセージ内に含まれる%sや%dの部分に対応する変数を指定する
+ * @author H.Kumagai
+ */
+void CmnLog_PutCmnClibLog(CMN_LOG_LEVEL level, const char* msg, ...)
+{
+	va_list args;
+
+	/* ログレベルチェック */
+	if ((gLogExCmnClib == NULL && gLogEx != NULL && level > gLogEx->level)
+			|| (gLogExCmnClib != NULL && level > gLogExCmnClib->level)) {
+		return;
+	}
+
+	/* ログ出力 */
+	va_start(args, msg);
+	if (gLogExCmnClib != NULL) {
+		cmnLogEx_PutLog(gLogExCmnClib, level, msg, args);
+	}
+	else {
+		cmnLogEx_PutLog(gLogEx, level, msg, args);
+	}
+	va_end(args);
+}

--- a/cmn-clib/src/CommonLog/CommonLogEx.c
+++ b/cmn-clib/src/CommonLog/CommonLogEx.c
@@ -31,25 +31,41 @@
 #include<stdlib.h>
 #include<string.h>
 #include<stdarg.h>
+#include<time.h>
 
 #include"cmnclib/Common.h"
 #include"cmnclib/CommonLog.h"
 #include"cmnclib/CommonTime.h"
+
+static const char* CMN_LOG_LEVEL_NAMES[] = {
+	"",
+	"ERROR",
+	"WARN",
+	"INFO",
+	"DEBUG",
+	"TRACE"
+};
+
+static char* timeFormat(int type, char* buf);
+static void mutexLock(CmnThreadMutex* mutex);
+static void mutexUnLock(CmnThreadMutex* mutex);
 
 /**
  * @brief 拡張ログ出力関数初期化処理
  *
  *  ログメッセージ定義ファイルを読み込み、拡張ログ出力関数の使用準備をする。<BR>
  *  拡張ログ出力関数を使用する前にこの関数をコールしなければならない。<BR>
- *  また、拡張ログ出力関数の使用後は、CmnLog_EndEx()関数をコールすること。<BR>
+ *  また、拡張ログ出力関数の使用後は、CmnLogEx_Free()関数をコールすること。<BR>
  *  標準ログ出力関数と異なり、複数のログ出力設定をすることが出来る。
  *
- * @param msgFile   (I)   ログメッセージ定義ファイルへのパス<BR>
- *                        定義ファイルの構文は、CmnLog_Init()関数を参照のこと。
+ * @param logFile   (I)   ログを出力するファイルパスを指定する。<BR>
+ *                        NULLを指定した場合は標準出力にログを出力する。<BR>
+ *                        ファイルへの書き込みモードは、「追加書き込み」である。
  * @param level     (I)   ログ出力レベル。<BR>
  *                        指定可能な出力レベルについては、CmnLog_Init()関数を参照のこと。
- * @param file      (I)   ログを出力するファイル名を指定する。<BR>
- *                        ファイルへの書き込みモードは、「追加書き込み」である。
+ * @param msgFile   (I)   ログメッセージ定義ファイルへのパス。<BR>
+ *                        定義ファイルを使用しない場合はNULLを指定する。<BR>
+ *                        定義ファイルの構文は、CmnLog_Init()関数を参照のこと。
  * @return 初期化に成功した場合は、LogEx構造体へのポインタを返し、<BR>
  *         初期化に失敗した場合はNULLを返す。（以下のような場合に失敗する）<BR>
  *         msgFileのパスが不正な場合<BR>
@@ -59,33 +75,40 @@
  * @sa 標準ログ出力関数初期化処理 CmnLog_Init()
  * @author H.Kumagai
  */
-CmnLogEx *CmnLogEx_Init(const char *msgFile, int level, const char *file)
+CmnLogEx* CmnLogEx_Create(const char* logFile, CMN_LOG_LEVEL level, const char* msgFile)
 {
 	CmnLogEx *log;
-
-	/* 引数不正チェック */
-	if (msgFile == NULL)          return NULL;
-	if (level > CMN_LOG_LEVEL_MAX) return NULL;
-	if (file == NULL)             return NULL;
 
 	/* 拡張ログ情報を取得、設定 */
 	if ((log = malloc(sizeof(CmnLogEx))) == NULL) {
 		return NULL;
 	}
 	memset(log, 0, sizeof(CmnLogEx));
+
+	if (logFile != NULL) {
+		if ((log->file = malloc(strlen(logFile) + 1)) == NULL) {
+			CmnLogEx_Free(log);
+			return NULL;
+		}
+		strcpy(log->file, logFile);
+	}
+
+	if (msgFile != NULL) {
+		log->list = CmnLogMessage_Create(msgFile);
+		if (log->list == NULL) {
+			CmnLogEx_Free(log);
+			return NULL;
+		}
+	}
+
+	log->mutex = CmnThreadMutex_Create();
+	if (log->mutex == NULL) {
+		CmnLogEx_Free(log);
+		return NULL;
+	}
+
+	/* 設定途中にログ出力しないよう、レベルの設定はログ設定が完了してから行う。 */
 	log->level = level;
-
-	if ((log->file = malloc(strlen(file) + 1)) == NULL) {
-		CmnLogEx_End(log);
-		return NULL;
-	}
-	strcpy(log->file, file);
-
-	log->list = _CmnLogMessage_Create(msgFile);
-	if (log->list == NULL) {
-		CmnLogEx_End(log);
-		return NULL;
-	}
 
 	return log;
 }
@@ -100,14 +123,21 @@ CmnLogEx *CmnLogEx_Init(const char *msgFile, int level, const char *file)
  * @param log    (I/O) 拡張ログ情報へのポインタ
  * @author H.Kumagai
  */
-void CmnLogEx_End(CmnLogEx *log)
+void CmnLogEx_Free(CmnLogEx *log)
 {
 	if (log == NULL) return;
+
+	/* 中途半端なログ出力をしないよう、出力レベルをNothingに設定 */
+	log->level = CMN_LOG_LEVEL_NOTHING;
+
 	if (log->list != NULL) {
-		_CmnLogMessage_Free(log->list);
+		CmnLogMessage_Free(log->list);
 	}
 	if (log->file != NULL) {
 		free(log->file);
+	}
+	if (log->mutex != NULL) {
+		CmnThreadMutex_Free(log->mutex);
 	}
 	free(log);
 }
@@ -118,7 +148,30 @@ void CmnLogEx_End(CmnLogEx *log)
  *
  *  ログを出力する。出力先はCmnLog_InitEx()関数の引数fileに指定したファイル。<BR>
  *  <ログ出力例><BR>
- *    yyyy/mm/dd[hh:mm:ss] CODE=メッセージコード : メッセージ本文
+ *    yyyy/mm/dd[hh:mm:ss] [level] メッセージ本文
+ *
+ * @param log              (I) 拡張ログ情報構造体へのポインタ（CmnLog_InitEx()関数の戻り値）
+ * @param level            (I) ログレベル。LoggerInitで指定されたログレベルと比較し、出力可否を決める。
+ * @param msg              (I) メッセージ文言
+ * @param ...              (I) メッセージ内に含まれる%sや%dの部分に対応する変数を指定する
+ * @author H.Kumagai
+ * @note メッセージコードが存在しない場合は何も出力されない
+ */
+void CmnLogEx_Put(CmnLogEx* log, CMN_LOG_LEVEL level, const char* msg, ...)
+{
+	va_list args;
+
+	va_start(args, msg);
+	cmnLogEx_PutLog(log, level, msg, args);
+	va_end(args);
+}
+
+/**
+ * @brief 拡張ログ出力
+ *
+ *  ログを出力する。出力先はCmnLog_InitEx()関数の引数fileに指定したファイル。<BR>
+ *  <ログ出力例><BR>
+ *    yyyy/mm/dd[hh:mm:ss] [level] msgCodeに対応するメッセージ文言
  *
  * @param log              (I) 拡張ログ情報構造体へのポインタ（CmnLog_InitEx()関数の戻り値）
  * @param level            (I) ログレベル。LoggerInitで指定されたログレベルと比較し、出力可否を決める。
@@ -127,13 +180,42 @@ void CmnLogEx_End(CmnLogEx *log)
  * @author H.Kumagai
  * @note メッセージコードが存在しない場合は何も出力されない
  */
-void CmnLogEx_Put(CmnLogEx *log, int level, const char *msgCode, ...)
+void CmnLogEx_PutByCode(CmnLogEx *log, CMN_LOG_LEVEL level, const char *msgCode, ...)
 {
 	va_list args;
+	CmnLogMessage msg;
+
+	/* 出力メッセージを取得 */
+	if ( ! CmnLogMessage_Get(log->list, msgCode, &msg)) {
+		return ;
+	}
+
+	/* メッセージ本文を出力 */
+	va_start(args, msgCode);
+	cmnLogEx_PutLog(log, level, msg.msg, args);
+	va_end(args);
+}
+
+
+/**
+ * @brief 拡張ログ出力（内部用関数）
+ *
+ *  ログを出力する。<BR>
+ *  <ログ出力例><BR>
+ *    yyyy/mm/dd[hh:mm:ss] [level] メッセージ本文
+ *
+ * @param log              (I) 拡張ログ情報構造体へのポインタ（CmnLog_InitEx()関数の戻り値）
+ * @param level            (I) ログレベル。LoggerInitで指定されたログレベルと比較し、出力可否を決める。
+ * @param msg              (I) メッセージ文言
+ * @param args             (I) メッセージ内に含まれる%sや%dの部分に対応する変数を指定する
+ * @author H.Kumagai
+ * @note メッセージコードが存在しない場合は何も出力されない
+ */
+void cmnLogEx_PutLog(CmnLogEx* log, CMN_LOG_LEVEL level, const char* msg, va_list args)
+{
 	char str_date[CMN_TIME_FORMAT_SIZE_ALL];
 	char format[512];
-	CmnLogMessage msg;
-	FILE *file;
+	FILE* file;
 
 	if (log == NULL) return;
 
@@ -141,26 +223,70 @@ void CmnLogEx_Put(CmnLogEx *log, int level, const char *msgCode, ...)
 	if (level > log->level) return;
 
 	/* 書式フォーマットされた現在時刻文字列を取得 */
-	CmnTime_Format(CMN_TIME_FORMAT_ALL, str_date);
+	timeFormat(CMN_TIME_FORMAT_ALL, str_date);
 
-	/* 出力メッセージを取得 */
-	if ( ! _CmnLogMessage_Get(log->list, msgCode, &msg)) {
-		return ;
+	/* START Synchronized */
+	mutexLock(log->mutex);
+
+	/* ログファイルオープン */
+	if (log->file != NULL) {
+		if ((file = fopen(log->file, "a")) == NULL) {
+			return;
+		}
+	}
+	else {
+		file = stdout;
 	}
 
-	if ((file = fopen(log->file, "a")) == NULL) {
-		return ;
-	}
-
-	/* 時刻、メッセージコード部分を出力 */
-	sprintf(format, "%s CODE=%s : ", str_date, msg.code);
+	/* 時刻、ログレベルを出力 */
+	sprintf(format, "%s [%5s] ", str_date, CMN_LOG_LEVEL_NAMES[level]);
 	fprintf(file, format);
 
 	/* メッセージ本文を出力 */
-	va_start(args, msgCode);
-	vfprintf(file, strcat(msg.msg, "\n"), args);
-	va_end(args);
+	vfprintf(file, msg, args);
+	fprintf(file, "\n");
 
-	fclose(file);
+	if (log->file != NULL) {
+		fclose(file);
+	}
+
+	/* END Synchronized */
+	mutexUnLock(log->mutex);
 }
 
+static char* timeFormat(int type, char* buf)
+{
+	struct tm* ptime;
+	time_t now;
+
+	time(&now);
+	ptime = localtime(&now);
+
+	/* 年、月情報の修正 */
+	ptime->tm_year += 1900;
+	ptime->tm_mon += 1;
+
+	sprintf(buf, "%04d/%02d/%02d %02d:%02d:%02d",
+		ptime->tm_year, ptime->tm_mon, ptime->tm_mday,
+		ptime->tm_hour, ptime->tm_min, ptime->tm_sec);
+
+	return buf;
+}
+
+static void mutexLock(CmnThreadMutex* mutex)
+{
+#if IS_PRATFORM_WINDOWS()
+	WaitForSingleObject(mutex->mutexId, INFINITE);
+#else
+	pthread_mutex_lock(&(mutex->mutexId));
+#endif
+}
+
+static void mutexUnLock(CmnThreadMutex* mutex)
+{
+#if IS_PRATFORM_WINDOWS()
+	ReleaseMutex(mutex->mutexId);
+#else
+	pthread_mutex_unlock(&(mutex->mutexId));
+#endif
+}

--- a/cmn-clib/src/CommonLog/CommonLogMessage.c
+++ b/cmn-clib/src/CommonLog/CommonLogMessage.c
@@ -1,0 +1,168 @@
+/** @file *********************************************************************
+ * @brief ログメッセージ定義 共通関数
+ *
+ *  ログメッセージ定義ファイルを扱う共通関数。<BR>
+ *  ログ出力メッセージの書式は以下。printf書式が使用可能。<BR>
+ * <BR>
+ *  ＜ログメッセージ定義ファイル例＞<BR>
+ * --- message.conf（メッセージログファイル） ---------------------<BR>
+ * C001, テストログ%s<BR>
+ * C002, テスト%d回目%s<BR>
+ * ----------------------------------------------------------------<BR>
+ *
+ * @author H.Kumagai
+ * @date   2004-06-06
+ * $Revision: 1.2 $
+ *****************************************************************************/
+#include<stdio.h>
+#include<stdlib.h>
+#include<string.h>
+
+#include"cmnclib/Common.h"
+#include"cmnclib/CommonLog.h"
+#include"cmnclib/CommonString.h"
+
+#define MSG_BUFSIZ   2048
+#define PARSE_CHAR   ','
+#define COMMENT_CHAR '#'
+
+/**
+ * @brief ログメッセージ定義ファイル読み込み
+ *
+ *  ログメッセージファイルの読み込みを行い、
+ *  LogMessage構造体にデータを格納する。
+ *
+ * @param msgFile    (I)   ログメッセージ定義ファイルへのパス<BR>
+ * @retval LogMessageへのポインタ 読み込み完了
+ * @retval NULL False 読み込み失敗（以下のような場合に失敗する）<BR>
+ *              fileが無効なポインタの場合<BR>
+ *              メッセージ定義ファイルの文法が不正な場合<BR>
+ * @author H.Kumagai
+ * @note この関数は、ログ出力共通関数から使用される。外部からの使用は禁止。
+ */
+CmnLogMessage *CmnLogMessage_Create(const char *msgFile)
+{
+	FILE *fp;
+	CmnLogMessage *list = NULL;
+	CmnLogMessage *tmp;
+	char  buf[MSG_BUFSIZ];
+	char *code_pos;
+	char *code_buf;
+	char *msg_pos;
+	char *msg_buf;
+
+	fp = fopen(msgFile, "r");
+	if (fp == NULL) {
+		return NULL;
+	}
+
+	while (fgets(buf, MSG_BUFSIZ, fp)) {
+		/* コメントもしくは空行であれば無視 */
+		if(CmnString_Trim(buf)[0] == '\n' || CmnString_Trim(buf)[0] == COMMENT_CHAR) {
+			continue ;
+		}
+
+		/* コードとメッセージへのポインタを取得（同時に区切り文字を'\0'に変換） */
+		msg_pos = strchr(buf, PARSE_CHAR);
+		if (msg_pos == NULL) {
+			fclose(fp);
+			return NULL;
+		}
+		*msg_pos = '\0';
+		msg_pos++ ;
+		code_pos = buf;
+
+		/* 改行コードを除去 */
+		if (msg_pos[strlen(msg_pos) - 1] == '\n') {
+			msg_pos[strlen(msg_pos) - 1] = '\0';
+		}
+
+		/* コードとメッセージの領域を確保 */
+		code_buf = malloc(strlen(code_pos) + 1);
+		strcpy(code_buf, CmnString_Trim(code_pos));
+		msg_buf = malloc(strlen(msg_pos) + 1);
+		strcpy(msg_buf, CmnString_Trim(msg_pos));
+
+		/* 最初のリストを作成 */
+		if (list == NULL) {
+			list = (CmnLogMessage *)calloc(1, sizeof(CmnLogMessage));
+			if (list == NULL) {
+				return NULL;
+			}
+			list->code = code_buf;
+			list->msg  = msg_buf;
+			list->next = NULL;
+			tmp = list;
+		}
+		/* 2番目以降のリストを作成 */
+		else {
+			tmp->next = (CmnLogMessage *)calloc(1, sizeof(CmnLogMessage));
+			tmp = tmp->next;
+			tmp->code = code_buf;
+			tmp->msg  = msg_buf;
+			tmp->next = NULL;
+		}
+	}
+	fclose(fp);
+	return list;
+}
+
+
+/**
+ * @brief ログメッセージリスト解放処理
+ *
+ *  ログメッセージリストのメモリ領域を解放する
+ *
+ * @param list    (I)   解放するログメッセージリストへのポインタ
+ * @author H.Kumagai
+ * @note この関数は、ログ出力共通関数から使用される。外部からの使用は禁止。
+ */
+void CmnLogMessage_Free(CmnLogMessage *list)
+{
+	CmnLogMessage *p;
+	CmnLogMessage *tmp;
+
+	if (list == NULL) {
+		return;
+	}
+
+	for (p = list; p; p = tmp) {
+		tmp = p->next;
+
+		free(p->code);
+		free(p->msg);
+		free(p);
+	}
+}
+
+
+/**
+ * @brief ログメッセージ取得
+ *
+ *  メッセージコードに対応したメッセージコード文字列とメッセージ文字列を取得する
+ *
+ * @param list         (I) ログメッセージリスト
+ * @param msg_code     (I) メッセージコード
+ * @param msg          (O) LogMessage構造体へのポインタを指定する。<BR>
+ *                         メッセージ取得成功時には、msg->codeとmsg->msgに値が格納される
+ * @retval True 取得成功時
+ * @retval False 取得失敗時（該当するメッセージコードが存在しない場合）
+ * @author H.Kumagai
+ * @note この関数は、ログ出力共通関数から使用される。外部からの使用は禁止。
+ */
+int CmnLogMessage_Get(CmnLogMessage *list, const char *msg_code, CmnLogMessage *msg)
+{
+	CmnLogMessage *p;
+
+	if (list == NULL) return False;
+
+	for (p = list; p; p = p->next){
+		if (strcmp(p->code, msg_code) == EQUAL) {
+			msg->code = p->code;
+			msg->msg  = p->msg;
+			return True;
+		}
+	}
+	return False;
+}
+

--- a/cmn-clib/src/CommonNet/CommonNetHttp.c
+++ b/cmn-clib/src/CommonNet/CommonNetHttp.c
@@ -5,6 +5,7 @@
 
 #include "cmnclib/CommonNet.h"
 #include "cmnclib/CommonData.h"
+#include"cmnclib/CommonLog.h"
 
 /**
  * @brief HTTPのGETリクエストを送信する
@@ -15,8 +16,10 @@
  */
 CmnNetHttpResponse* CmnNetHttp_GetRequest(const char *ip, unsigned short port, const char *path)
 {
+	CMNLOG_TRACE_START();
 	/* TODO:ヘッダー情報も指定可能な様に機能追加 */
 	/* TODO:実装 */
+	CMNLOG_TRACE_END();
 	return NULL;
 }
 
@@ -30,8 +33,10 @@ CmnNetHttpResponse* CmnNetHttp_GetRequest(const char *ip, unsigned short port, c
  */
 CmnNetHttpResponse* CmnNetHttp_PostRequest(const char *ip, unsigned short port, const char *path, CmnDataBuffer *requestBody)
 {
+	CMNLOG_TRACE_START();
 	/* TODO:ヘッダー情報も指定可能な様に機能追加 */
 	/* TODO:実装 */
+	CMNLOG_TRACE_END();
 	return NULL;
 }
 

--- a/cmn-clib/src/CommonString/CommonString.c
+++ b/cmn-clib/src/CommonString/CommonString.c
@@ -13,7 +13,7 @@
 
 #include"cmnclib/Common.h"
 #include"cmnclib/CommonString.h"
-
+#include"cmnclib/CommonLog.h"
 
 /**
  * @brief 右側トリム
@@ -27,13 +27,16 @@
 char *CmnString_RTrim(char *str)
 {
 	int len;
+	CMNLOG_TRACE_START();
 
 	if ( ! str) {
+		CMNLOG_TRACE_END();
 		return str;
 	}
 
 	len = strlen(str) - 1;
 	if (len <= 0) {
+		CMNLOG_TRACE_END();
 		return str;
 	}
 
@@ -46,6 +49,7 @@ char *CmnString_RTrim(char *str)
 	len++;
 	*(str + len) = '\0';
 
+	CMNLOG_TRACE_END();
 	return str;
 }
 
@@ -63,7 +67,10 @@ char *CmnString_RTrim(char *str)
  */
 char *CmnString_LTrim(char *str)
 {
+	CMNLOG_TRACE_START();
 	for (; *str && (*str == ' '); str++) ;
+
+	CMNLOG_TRACE_END();
 	return str;
 }
 
@@ -79,7 +86,13 @@ char *CmnString_LTrim(char *str)
  */
 char *CmnString_Trim(char *str)
 {
-	return CmnString_RTrim(CmnString_LTrim(str));
+	char *ret;
+	CMNLOG_TRACE_START();
+
+	ret = CmnString_RTrim(CmnString_LTrim(str));
+
+	CMNLOG_TRACE_END();
+	return ret;
 }
 
 /**
@@ -96,6 +109,8 @@ char *CmnString_Trim(char *str)
 char* CmnString_Replace(const char *src, const char *befor, const char *after, char *dest)
 {
 	size_t oldlen;
+	CMNLOG_TRACE_START();
+
 	oldlen = strlen(befor);
 
 	*dest = '\0';
@@ -113,6 +128,7 @@ char* CmnString_Replace(const char *src, const char *befor, const char *after, c
 		}
 	}
 
+	CMNLOG_TRACE_END();
 	return dest;
 }
 
@@ -131,6 +147,8 @@ char* CmnString_ReplaceNew(const char *src, const char *befor, const char *after
 	size_t srclen, oldlen, newlen;
 	size_t bufsize;
 	char *dest;
+	char *ret;
+	CMNLOG_TRACE_START();
 
 	/* 元文字列のサイズから必要十分なバッファサイズを算出 */
 	srclen = strlen(src);
@@ -142,7 +160,10 @@ char* CmnString_ReplaceNew(const char *src, const char *befor, const char *after
 	dest = malloc(bufsize);
 	memset(dest, '\0', bufsize);
 
-	return CmnString_Replace(src, befor, after, dest);
+	ret = CmnString_Replace(src, befor, after, dest);
+
+	CMNLOG_TRACE_END();
+	return ret;
 }
 
 /**
@@ -157,11 +178,18 @@ char* CmnString_ReplaceNew(const char *src, const char *befor, const char *after
 char* CmnString_StrCatNew(const char *left, const char *right)
 {
 	char *buf;
-	size_t bufsize = strlen(left) + strlen(right) + 1;
+	size_t bufsize;
+	char *ret;
+	CMNLOG_TRACE_START();
+
+	bufsize = strlen(left) + strlen(right) + 1;
 	buf = malloc(bufsize);
 	memset(buf, '\0', bufsize);
 
-	return strcat(strcat(buf, left), right);
+	ret = strcat(strcat(buf, left), right);
+
+	CMNLOG_TRACE_END();
+	return ret;
 }
 
 /**
@@ -172,10 +200,18 @@ char* CmnString_StrCatNew(const char *left, const char *right)
  * @param str  (I) 文字列
  * @return コピーした文字列へのポインタを返却する。呼び出し元でfreeすること。
  */
-char* CmnString_StrCopyNew(const char *str)
+char* CmnString_StrCopyNew(const char* str)
 {
-	char *buf = calloc(1, strlen(str) + 1);
-	return strcpy(buf, str);
+	char *buf;
+	CMNLOG_TRACE_START();
+
+	buf = calloc(1, strlen(str) + 1);
+	if (buf != NULL) {
+		strcpy(buf, str);
+	}
+
+	CMNLOG_TRACE_END();
+	return buf;
 }
 
 /**
@@ -196,6 +232,7 @@ int CmnString_Split(char *buf, size_t rowlen, size_t collen, const char *str, co
 	const char *pos = str;
 	size_t delimlen;
 	size_t row = 0;
+	CMNLOG_TRACE_START();
 
 	delimlen = strlen(delim);
 
@@ -223,6 +260,7 @@ int CmnString_Split(char *buf, size_t rowlen, size_t collen, const char *str, co
 		}
 	}
 
+	CMNLOG_TRACE_END();
 	return row;
 }
 
@@ -238,6 +276,7 @@ char* CmnString_Lpad(char *buf, const char *str, char padch, size_t digit)
 {
 	size_t stlen = 0;
 	size_t padlen = 0;
+	CMNLOG_TRACE_START();
 
 	stlen = strlen(str);
 
@@ -250,6 +289,7 @@ char* CmnString_Lpad(char *buf, const char *str, char padch, size_t digit)
 	/* add str */
 	strcpy(buf + padlen, str);
 
+	CMNLOG_TRACE_END();
 	return buf;
 }
 
@@ -265,6 +305,7 @@ char* CmnString_Rpad(char *buf, const char *str, char padch, size_t digit)
 {
 	size_t stlen = 0;
 	size_t padlen = 0;
+	CMNLOG_TRACE_START();
 
 	strcpy(buf, str);
 	stlen = strlen(str);
@@ -275,6 +316,7 @@ char* CmnString_Rpad(char *buf, const char *str, char padch, size_t digit)
 		memset(buf + stlen, padch, padlen);
 	}
 
+	CMNLOG_TRACE_END();
 	return buf;
 }
 
@@ -286,10 +328,14 @@ char* CmnString_Rpad(char *buf, const char *str, char padch, size_t digit)
  */
 int CmnString_StartWith(const char *str, const char *mark)
 {
+	int ret = 0;
+	CMNLOG_TRACE_START();
+
 	if (strstr(str, mark) == EQUAL) {
 		return 1;
 	}
-	return 0;
+	CMNLOG_TRACE_END();
+	return ret;
 }
 
 /**
@@ -302,13 +348,17 @@ int CmnString_EndWith(const char *str, const char *mark)
 {
 	int strLen;
 	int markLen;
+	int ret = 0;
+	CMNLOG_TRACE_START();
 
 	strLen = strlen(str);
 	markLen = strlen(mark);
 
 	if (strcmp(str + strLen - markLen, mark) == EQUAL) {
-		return 1;
+		ret = 1;
 	}
-	return 0;
+
+	CMNLOG_TRACE_END();
+	return ret;
 }
 

--- a/cmn-clib/src/CommonString/CommonStringBuffer.c
+++ b/cmn-clib/src/CommonString/CommonStringBuffer.c
@@ -10,6 +10,7 @@
 #include<string.h>
 
 #include "cmnclib/CommonString.h"
+#include "cmnclib/CommonLog.h"
 
 /**
  * @brief 自動領域拡張バッファ作成
@@ -22,24 +23,31 @@
 CmnStringBuffer* CmnStringBuffer_Create(const char *str)
 {
 	size_t strLen = 0;
-	CmnStringBuffer *ret = malloc(sizeof(CmnStringBuffer));
+	CmnStringBuffer *ret;
+	CMNLOG_TRACE_START();
+
+	ret = malloc(sizeof(CmnStringBuffer));
 	if (ret == NULL) {
+		CMNLOG_TRACE_END();
 		return NULL;
 	}
 
 	if (str == NULL) {
+		CMNLOG_TRACE_END();
 		str = "";
 	}
 	strLen = strlen(str);
 
 	ret->_buf = CmnDataBuffer_Create(strLen + 1);
 	if (ret->_buf == NULL) {
+		CMNLOG_TRACE_END();
 		return NULL;
 	}
 	CmnDataBuffer_Set(ret->_buf, str, strLen + 1);
 	ret->string = ret->_buf->data;
 	ret->length = strLen;
 
+	CMNLOG_TRACE_END();
 	return ret;
 }
 
@@ -54,18 +62,23 @@ CmnStringBuffer* CmnStringBuffer_Create(const char *str)
  */
 int CmnStringBuffer_Append(CmnStringBuffer *buf, const char *str)
 {
-	size_t strLen = strlen(str);
+	size_t strLen;
+	CMNLOG_TRACE_START();
+
+	strLen = strlen(str);
 
 	/* '\0'を削除 */
 	CmnDataBuffer_Delete(buf->_buf, 1);
 	/* 文字列を追加 */
 	if (CmnDataBuffer_Append(buf->_buf, str, strLen + 1) != 0) {
+		CMNLOG_TRACE_END();
 		return -1;
 	}
 
 	buf->string = buf->_buf->data;
 	buf->length += strLen;
 
+	CMNLOG_TRACE_END();
 	return 0;
 }
 
@@ -80,16 +93,21 @@ int CmnStringBuffer_Append(CmnStringBuffer *buf, const char *str)
  */
 int CmnStringBuffer_Set(CmnStringBuffer *buf, const char *str)
 {
-	size_t strLen = strlen(str);
+	size_t strLen;
+	CMNLOG_TRACE_START();
+	
+	strLen = strlen(str);
 
 	/* 文字列を設定 */
 	if (CmnDataBuffer_Set(buf->_buf, str, strLen + 1) != 0) {
+		CMNLOG_TRACE_END();
 		return -1;
 	}
 
 	buf->string = buf->_buf->data;
 	buf->length = strLen;
 
+	CMNLOG_TRACE_END();
 	return 0;
 }
 
@@ -102,7 +120,9 @@ int CmnStringBuffer_Set(CmnStringBuffer *buf, const char *str)
  */
 void CmnStringBuffer_Free(CmnStringBuffer *buf)
 {
+	CMNLOG_TRACE_START();
 	free(buf->_buf);
 	free(buf);
+	CMNLOG_TRACE_END();
 }
 

--- a/cmn-clib/src/CommonString/CommonStringList.c
+++ b/cmn-clib/src/CommonString/CommonStringList.c
@@ -15,7 +15,7 @@
 #include"cmnclib/Common.h"
 #include"cmnclib/CommonString.h"
 #include"cmnclib/CommonData.h"
-
+#include"cmnclib/CommonLog.h"
 
 /**
  * @brief 文字列リスト作成
@@ -27,7 +27,13 @@
  */
 CmnStringList *CmnStringList_Create()
 {
-	return (CmnStringList *)CmnDataList_Create();
+	CmnStringList *ret;
+	CMNLOG_TRACE_START();
+
+	ret = (CmnStringList *)CmnDataList_Create();
+
+	CMNLOG_TRACE_END();
+	return ret;
 }
 
 
@@ -41,7 +47,9 @@ CmnStringList *CmnStringList_Create()
  */
 void CmnStringList_Free(CmnStringList *list)
 {
+	CMNLOG_TRACE_START();
 	CmnDataList_Free((CmnDataList *)list, free);
+	CMNLOG_TRACE_END();
 }
 
 
@@ -59,12 +67,15 @@ void CmnStringList_Free(CmnStringList *list)
 void CmnStringList_Add(CmnStringList *list, const char *str)
 {
 	char *data;
+	CMNLOG_TRACE_START();
 
 	data = malloc(strlen(str) + 1);
 	if (data) {
 		strcpy(data, str);
 	}
 	CmnDataList_Add((CmnDataList *)list, data);
+
+	CMNLOG_TRACE_END();
 }
 
 
@@ -80,6 +91,12 @@ void CmnStringList_Add(CmnStringList *list, const char *str)
  */
 char *CmnStringList_Get(CmnStringList *list, int index)
 {
-	return (char *)CmnDataList_Get((CmnDataList *)list, index);
+	char *ret;
+	CMNLOG_TRACE_START();
+
+	ret = (char *)CmnDataList_Get((CmnDataList *)list, index);
+
+	CMNLOG_TRACE_END();
+	return ret;
 }
 

--- a/cmn-clib/src/CommonTest/CommonTest.c
+++ b/cmn-clib/src/CommonTest/CommonTest.c
@@ -48,6 +48,7 @@
 #include "cmnclib/CommonData.h"
 #include "cmnclib/CommonTime.h"
 #include "cmnclib/CommonString.h"
+#include"cmnclib/CommonLog.h"
 
 #define REPORT_BUF_SIZE_OF_DUMP 1024
 #define REPORT_BUF_SIZE_OF_ONE_CALSE 4096
@@ -75,7 +76,10 @@ void CmnTest_InitializeTestPlan(CmnTestPlan *plan)
  */
 void CmnTest_AddTestCase(CmnTestPlan *plan, char *fileName, char *caseName, void (*testFunction)())
 {
-	CmnTestCase *testCase = calloc(1, sizeof(CmnTestCase));
+	CmnTestCase *testCase;
+	CMNLOG_TRACE_START();
+
+	testCase = calloc(1, sizeof(CmnTestCase));
 	testCase->testFileName = fileName;
 	testCase->testCaseName = caseName;
 	testCase->testFunction = testFunction;
@@ -83,6 +87,8 @@ void CmnTest_AddTestCase(CmnTestPlan *plan, char *fileName, char *caseName, void
 	testCase->actual = NULL;
 	testCase->expected = NULL;
 	CmnDataList_Add(plan->caseList, testCase);
+
+	CMNLOG_TRACE_END();
 }
 
 /**
@@ -93,10 +99,12 @@ void CmnTest_AddTestCase(CmnTestPlan *plan, char *fileName, char *caseName, void
 void CmnTest_Run(CmnTestPlan *plan, _Bool realtimeReport)
 {
 	CmnTestCase *testCase;
+
 	char reportTmp[REPORT_BUF_SIZE_OF_ONE_CALSE];
 	char expectedTmp[REPORT_BUF_SIZE_OF_DUMP];
 	char actualTmp[REPORT_BUF_SIZE_OF_DUMP];
 	int i = 0;
+	CMNLOG_TRACE_START();
 
 	/* レポートの初期化 */
 	plan->report = calloc(plan->caseList->size * REPORT_BUF_SIZE_OF_ONE_CALSE, sizeof(char));
@@ -140,6 +148,7 @@ void CmnTest_Run(CmnTestPlan *plan, _Bool realtimeReport)
 
 	/* テスト終了時間記録 */
 	CmnTimeDateTime_SetNow(&plan->endTime);
+	CMNLOG_TRACE_END();
 }
 
 /**
@@ -150,6 +159,7 @@ void CmnTest_DestroyTest(CmnTestPlan *plan)
 {
 	int i;
 	CmnTestCase *testCase;
+	CMNLOG_TRACE_START();
 
 	/* 実測値、期待値を解放 */
 	for (i = 0; i < plan->caseList->size; i++) {
@@ -163,6 +173,7 @@ void CmnTest_DestroyTest(CmnTestPlan *plan)
 
 	/* レポートの解放 */
 	free(plan->report);
+	CMNLOG_TRACE_END();
 }
 
 /*
@@ -175,8 +186,11 @@ void CmnTest_DestroyTest(CmnTestPlan *plan)
  */
 _Bool CmnTest_AssertNumber(CmnTestCase *testCase, long line, long actual, long expected)
 {
+	CMNLOG_TRACE_START();
+
 	/* すでに検証NGの場合は検証しない */
 	if ( ! testCase->result) {
+		CMNLOG_TRACE_END();
 		return False;
 	}
 
@@ -188,9 +202,11 @@ _Bool CmnTest_AssertNumber(CmnTestCase *testCase, long line, long actual, long e
 		testCase->actual = CmnString_StrCatNew(buf, "");
 		sprintf(buf, "%ld", expected);
 		testCase->expected = CmnString_StrCatNew(buf, "");
+		CMNLOG_TRACE_END();
 		return False;
 	}
 
+	CMNLOG_TRACE_END();
 	return True;
 }
 
@@ -204,8 +220,11 @@ _Bool CmnTest_AssertNumber(CmnTestCase *testCase, long line, long actual, long e
  */
 _Bool CmnTest_AssertString(CmnTestCase *testCase, long line, char *actual, char *expected)
 {
+	CMNLOG_TRACE_START();
+
 	/* すでに検証NGの場合は検証しない */
 	if ( ! testCase->result) {
+		CMNLOG_TRACE_END();
 		return False;
 	}
 
@@ -214,9 +233,11 @@ _Bool CmnTest_AssertString(CmnTestCase *testCase, long line, char *actual, char 
 		testCase->lineOfNg = line;
 		testCase->actual = CmnString_StrCatNew(actual, "");
 		testCase->expected = CmnString_StrCatNew(expected, "");
+		CMNLOG_TRACE_END();
 		return False;
 	}
 
+	CMNLOG_TRACE_END();
 	return True;
 }
 
@@ -267,8 +288,11 @@ char* toHexString(void *data, size_t len)
  */
 _Bool CmnTest_AssertData(CmnTestCase *testCase, long line, void *actual, void *expected, size_t dataLen)
 {
+	CMNLOG_TRACE_START();
+
 	/* すでに検証NGの場合は検証しない */
 	if ( ! testCase->result) {
+		CMNLOG_TRACE_END();
 		return False;
 	}
 
@@ -277,9 +301,11 @@ _Bool CmnTest_AssertData(CmnTestCase *testCase, long line, void *actual, void *e
 		testCase->lineOfNg = line;
 		testCase->actual = toHexString(actual, dataLen);
 		testCase->expected = toHexString(expected, dataLen);
+		CMNLOG_TRACE_END();
 		return False;
 	}
 
+	CMNLOG_TRACE_END();
 	return True;
 }
 
@@ -291,8 +317,11 @@ _Bool CmnTest_AssertData(CmnTestCase *testCase, long line, void *actual, void *e
  */
 _Bool CmnTest_AssertNG(CmnTestCase *testCase, long line)
 {
+	CMNLOG_TRACE_START();
+
 	/* すでに検証NGの場合は検証しない */
 	if ( ! testCase->result) {
+		CMNLOG_TRACE_END();
 		return False;
 	}
 
@@ -300,12 +329,14 @@ _Bool CmnTest_AssertNG(CmnTestCase *testCase, long line)
 	testCase->lineOfNg = line;
 	testCase->actual = CmnString_StrCatNew("no data", "");
 	testCase->expected = CmnString_StrCatNew("no data", "");
+	CMNLOG_TRACE_END();
 	return False;
 }
 
 static void cutAndCopyDumpText(char *buf, const char *str, size_t bufSize)
 {
 	char omitMark[] = "...";
+	CMNLOG_TRACE_START();
 
 	if (strlen(str) > (bufSize - 1)) {
 		size_t omitStart = bufSize - (strlen(omitMark) + 1);
@@ -316,5 +347,7 @@ static void cutAndCopyDumpText(char *buf, const char *str, size_t bufSize)
 	else {
 		strcpy(buf, str);
 	}
+
+	CMNLOG_TRACE_END();
 }
 

--- a/cmn-clib/src/CommonThread/CommonThread.c
+++ b/cmn-clib/src/CommonThread/CommonThread.c
@@ -5,6 +5,7 @@
 
 #include "cmnclib/Common.h"
 #include "cmnclib/CommonThread.h"
+#include "cmnclib/CommonLog.h"
 
 #if IS_PRATFORM_WINDOWS()
 	#include <windows.h>
@@ -17,7 +18,11 @@
 /* 呼出規約「__stdcall」を吸収するラッパ */
 static unsigned int __stdcall callMethodForWin(void *arg) {
 	CmnThread *thread = (CmnThread *)arg;
+	CMNLOG_TRACE_START();
+
 	thread->method(thread);
+
+	CMNLOG_TRACE_END();
 	return 0;
 }
 #endif
@@ -35,9 +40,11 @@ static unsigned int __stdcall callMethodForWin(void *arg) {
  */
 void CmnThread_Init(CmnThread *thread, void (*method)(CmnThread*), void *data, CmnThreadMutex *mutex)
 {
+	CMNLOG_TRACE_START();
 	thread->method = method;
 	thread->data = data;
 	thread->mutex = mutex;
+	CMNLOG_TRACE_END();
 }
 
 /**
@@ -53,6 +60,7 @@ int CmnThread_Start(CmnThread *thread)
 #if IS_PRATFORM_WINDOWS()
 	unsigned int dummy;
 	HANDLE tmpThreadId;
+	CMNLOG_TRACE_START();
 
 	/*
 	 * Memo : CreateThreadと_beginthreadexの違い
@@ -72,13 +80,17 @@ int CmnThread_Start(CmnThread *thread)
 
 	if (tmpThreadId == 0) {
 		/* 起動エラー */
+		CMNLOG_TRACE_END();
 		return -1;
 	}
 
 	thread->threadId = tmpThreadId;
+
+	CMNLOG_TRACE_END();
 	return 0;
 #else
 	pthread_t tmpThreadId;
+	CMNLOG_TRACE_START();
 	if (pthread_create(
 					&(thread->threadId),		/* スレッドIDを格納するポインタ */
 					NULL,						/* オプション指定 */
@@ -87,8 +99,11 @@ int CmnThread_Start(CmnThread *thread)
 			!= 0) {
 
 		/* 起動エラー */
+		CMNLOG_TRACE_END();
 		return -1;
 	}
+
+	CMNLOG_TRACE_END();
 	return 0;
 #endif
 }
@@ -102,11 +117,15 @@ int CmnThread_Start(CmnThread *thread)
  */
 void CmnThread_Join(CmnThread *thread)
 {
+	CMNLOG_TRACE_START();
+
 #if IS_PRATFORM_WINDOWS()
 	WaitForSingleObject(thread->threadId, INFINITE);
 #else
 	pthread_join(thread->threadId, NULL);
 #endif
+
+	CMNLOG_TRACE_END();
 }
 
 /**
@@ -118,11 +137,15 @@ void CmnThread_Join(CmnThread *thread)
  */
 void CmnThread_Kill(CmnThread *thread)
 {
+	CMNLOG_TRACE_START();
+
 #if IS_PRATFORM_WINDOWS()
 	TerminateThread(thread->threadId, 0);
 #else
 	pthread_cancel(thread->threadId);
 #endif
+
+	CMNLOG_TRACE_END();
 }
 
 /**
@@ -136,23 +159,29 @@ CmnThreadMutex* CmnThreadMutex_Create()
 {
 	CmnThreadMutex tmp;
 	CmnThreadMutex *ret;
+	CMNLOG_TRACE_START();
 
 #if IS_PRATFORM_WINDOWS()
 	tmp.mutexId = CreateMutex(NULL, FALSE, "CmnThreadMutex");
 	if (tmp.mutexId == 0) {
+		CMNLOG_TRACE_END();
 		return NULL;
 	}
 #else
 	if (pthread_mutex_init(&(tmp.mutexId), NULL) != 0) {
+		CMNLOG_TRACE_END();
 		return NULL;
 	}
 #endif
 
 	if ((ret = calloc(1, sizeof(CmnThreadMutex))) == NULL) {
+		CMNLOG_TRACE_END();
 		return NULL;
 	}
 
 	ret->mutexId = tmp.mutexId;
+
+	CMNLOG_TRACE_END();
 	return ret;
 }
 
@@ -165,11 +194,15 @@ CmnThreadMutex* CmnThreadMutex_Create()
  */
 void CmnThreadMutex_Lock(CmnThreadMutex *mutex)
 {
+	CMNLOG_TRACE_START();
+
 #if IS_PRATFORM_WINDOWS()
 	WaitForSingleObject(mutex->mutexId, INFINITE);
 #else
 	pthread_mutex_lock(&(mutex->mutexId));
 #endif
+
+	CMNLOG_TRACE_END();
 }
 
 /**
@@ -181,11 +214,15 @@ void CmnThreadMutex_Lock(CmnThreadMutex *mutex)
  */
 void CmnThreadMutex_UnLock(CmnThreadMutex *mutex)
 {
+	CMNLOG_TRACE_START();
+
 #if IS_PRATFORM_WINDOWS()
 	ReleaseMutex(mutex->mutexId);
 #else
 	pthread_mutex_unlock(&(mutex->mutexId));
 #endif
+
+	CMNLOG_TRACE_END();
 }
 
 /**
@@ -197,6 +234,8 @@ void CmnThreadMutex_UnLock(CmnThreadMutex *mutex)
  */
 void CmnThreadMutex_Free(CmnThreadMutex *mutex)
 {
+	CMNLOG_TRACE_START();
+
 #if IS_PRATFORM_WINDOWS()
 	CloseHandle(mutex->mutexId);
 #else
@@ -204,5 +243,6 @@ void CmnThreadMutex_Free(CmnThreadMutex *mutex)
 #endif
 
 	free(mutex);
+	CMNLOG_TRACE_END();
 }
 

--- a/cmn-clib/src/CommonTime/CommonTime.c
+++ b/cmn-clib/src/CommonTime/CommonTime.c
@@ -14,6 +14,7 @@
 
 #include"cmnclib/Common.h"
 #include"cmnclib/CommonTime.h"
+#include"cmnclib/CommonLog.h"
 
 #if IS_PRATFORM_WINDOWS()
 	#include <windows.h>
@@ -34,6 +35,7 @@ static const int BASE_MON = 1;		/* 月調整用の値。tm_monは0～11月で表
  */
 static void tmToDateTime(struct tm *time, CmnTimeDateTime *datetime)
 {
+	CMNLOG_TRACE_START();
 	datetime->year = time->tm_year + BASE_YEAR;
 	datetime->month = time->tm_mon + BASE_MON;
 	datetime->dayOfMonth = time->tm_mday;
@@ -43,6 +45,7 @@ static void tmToDateTime(struct tm *time, CmnTimeDateTime *datetime)
 	datetime->minute = time->tm_min;
 	datetime->second = time->tm_sec;
 	datetime->isdst = time->tm_isdst;
+	CMNLOG_TRACE_END();
 }
 
 /**
@@ -52,6 +55,7 @@ static void tmToDateTime(struct tm *time, CmnTimeDateTime *datetime)
  */
 static void dateTimeToTm(CmnTimeDateTime *datetime, struct tm *time)
 {
+	CMNLOG_TRACE_START();
 	time->tm_year = datetime->year - BASE_YEAR;
 	time->tm_mon = datetime->month - BASE_MON;
 	time->tm_mday = datetime->dayOfMonth;
@@ -61,6 +65,7 @@ static void dateTimeToTm(CmnTimeDateTime *datetime, struct tm *time)
 	time->tm_min = datetime->minute;
 	time->tm_sec = datetime->second;
 	time->tm_isdst = datetime->isdst;
+	CMNLOG_TRACE_END();
 }
 
 /**
@@ -73,7 +78,11 @@ static void dateTimeToTm(CmnTimeDateTime *datetime, struct tm *time)
  */
 CmnTimeDateTime* CmnTimeDateTime_SetNow(CmnTimeDateTime *datetime)
 {
-	return CmnTimeDateTime_SetBySerial(datetime, time(NULL));
+	CMNLOG_TRACE_START();
+	CmnTimeDateTime *ret;
+	ret = CmnTimeDateTime_SetBySerial(datetime, time(NULL));
+	CMNLOG_TRACE_END();
+	return ret;
 }
 
 /**
@@ -95,6 +104,8 @@ CmnTimeDateTime* CmnTimeDateTime_Set(CmnTimeDateTime *datetime, int year, int mo
 {
 	struct tm tmptm;
 	time_t time;
+	CmnTimeDateTime *ret;
+	CMNLOG_TRACE_START();
 
 	/* time_tを取得 */
 	tmptm.tm_year = year - BASE_YEAR;
@@ -107,7 +118,10 @@ CmnTimeDateTime* CmnTimeDateTime_Set(CmnTimeDateTime *datetime, int year, int mo
 	time = mktime(&tmptm);
 
 	/* DateTimeを作成 */
-	return CmnTimeDateTime_SetBySerial(datetime, time);
+	ret = CmnTimeDateTime_SetBySerial(datetime, time);
+
+	CMNLOG_TRACE_END();
+	return ret;
 }
 
 /**
@@ -122,6 +136,7 @@ CmnTimeDateTime* CmnTimeDateTime_Set(CmnTimeDateTime *datetime, int year, int mo
 CmnTimeDateTime* CmnTimeDateTime_SetBySerial(CmnTimeDateTime *datetime, time_t time)
 {
 	struct tm tmptm;
+	CMNLOG_TRACE_START();
 
 	/* tm取得 */
 #if IS_PRATFORM_WINDOWS()
@@ -135,6 +150,7 @@ CmnTimeDateTime* CmnTimeDateTime_SetBySerial(CmnTimeDateTime *datetime, time_t t
 	datetime->time = time;
 	datetime->timezone = 0;		/* タイムゾーン設定処理を実装すること */
 
+	CMNLOG_TRACE_END();
 	return datetime;
 }
 
@@ -160,6 +176,8 @@ CmnTimeDateTime* CmnTimeDateTime_Add(CmnTimeDateTime *datetime, int year, int mo
 {
 	struct tm tmptm;
 	time_t time;
+	CmnTimeDateTime *ret;
+	CMNLOG_TRACE_START();
 
 	/* struct tmに変換 */
 	dateTimeToTm(datetime, &tmptm);
@@ -174,7 +192,10 @@ CmnTimeDateTime* CmnTimeDateTime_Add(CmnTimeDateTime *datetime, int year, int mo
 
 	/* 変換 */
 	time = mktime(&tmptm);
-	return CmnTimeDateTime_SetBySerial(datetime, time);
+	ret = CmnTimeDateTime_SetBySerial(datetime, time);
+
+	CMNLOG_TRACE_END();
+	return ret;
 }
 
 /**
@@ -188,7 +209,13 @@ CmnTimeDateTime* CmnTimeDateTime_Add(CmnTimeDateTime *datetime, int year, int mo
  */
 CmnTimeDateTime* CmnTimeDateTime_AddBySerial(CmnTimeDateTime *datetime, time_t time)
 {
-	return CmnTimeDateTime_SetBySerial(datetime, datetime->time + time);
+	CmnTimeDateTime *ret;
+	CMNLOG_TRACE_START();
+
+	ret = CmnTimeDateTime_SetBySerial(datetime, datetime->time + time);
+
+	CMNLOG_TRACE_END();
+	return ret;
 }
 
 /**
@@ -198,6 +225,7 @@ CmnTimeDateTime* CmnTimeDateTime_AddBySerial(CmnTimeDateTime *datetime, time_t t
  */
 char* CmnTimeDateTime_ToString(const CmnTimeDateTime *datetime, char *buf)
 {
+	CMNLOG_TRACE_START();
 	*buf = '\0';
 	sprintf(buf, "time=%I64d, year=%d, month=%d, day(m)=%d, day(w)=%d, day(y)=%d, hour=%d, min=%d, sec=%d, isdst=%d, timezone=%ld",
 			datetime->time,
@@ -211,6 +239,7 @@ char* CmnTimeDateTime_ToString(const CmnTimeDateTime *datetime, char *buf)
 			datetime->second,
 			datetime->isdst,
 			datetime->timezone);
+	CMNLOG_TRACE_END();
 	return buf;
 }
 
@@ -252,6 +281,7 @@ char *CmnTime_Format(int type, char *buf)
 {
 	struct tm *ptime;
 	time_t now;
+	CMNLOG_TRACE_START();
 
 	time(&now);
 	ptime = localtime(&now);
@@ -304,6 +334,7 @@ char *CmnTime_Format(int type, char *buf)
 			*buf = '\0';
 	}
 
+	CMNLOG_TRACE_END();
 	return buf;
 }
 
@@ -313,9 +344,11 @@ char *CmnTime_Format(int type, char *buf)
  */
 void CmnTime_Sleep(unsigned long long msec)
 {
+	CMNLOG_TRACE_START();
 #if IS_PRATFORM_WINDOWS()
 	Sleep(msec);
 #else
 	usleep(msec * 1000);
 #endif
+	CMNLOG_TRACE_END();
 }

--- a/cmn-clib/test/src/test_CommonLog.c
+++ b/cmn-clib/test/src/test_CommonLog.c
@@ -9,12 +9,13 @@
 #include "cmnclib/CommonTest.h"
 #include "cmnclib/CommonLog.h"
 
-static void test_Xxx(CmnTestCase *testCase)
+static void test_CmnLogEx(CmnTestCase *testCase)
 {
-	/* TODO */
+	CmnLogEx* logex = CmnLogEx_Create("test.log", CMN_LOG_LEVEL_DEBUG, NULL);
+	CmnLogEx_Put(logex, CMN_LOG_LEVEL_DEBUG, "test[%s] val[%s]", "AAA", "BBB");
 }
 
 void test_CommonLog_AddCase(CmnTestPlan *plan)
 {
-	CmnTest_AddTestCaseEasy(plan, test_Xxx);
+	CmnTest_AddTestCaseEasy(plan, test_CmnLogEx);
 }

--- a/cmn-clib/test/src/test_main.c
+++ b/cmn-clib/test/src/test_main.c
@@ -5,8 +5,11 @@
  * $Revision: 1.5 $
  */
 #include<stdio.h>
+#include<string.h>
 
 #include"cmnclib/CommonTest.h"
+#include"cmnclib/CommonLog.h"
+#include"cmnclib/CommonTime.h"
 
 extern void test_CommonConf_AddCase(CmnTestPlan *plan);
 extern void test_CommonData_AddCase(CmnTestPlan *plan);
@@ -20,8 +23,14 @@ extern void test_CommonNet_AddCase(CmnTestPlan *plan);
 int main(int argc, char **argv)
 {
 	CmnTestPlan plan;
+	char timeBuf[64];
+	char logFileName[128] = "cmn-clib_test_";
 
 	printf("### Start test ###\n");
+
+	CmnTime_Format(CMN_TIME_FORMAT_ALL_SHORT, timeBuf);
+	CmnLog_Init(strcat(strcat(logFileName, timeBuf), ".log"), CMN_LOG_LEVEL_TRACE, NULL);
+	CmnLog_InitCmnClibLog(NULL, CMN_LOG_LEVEL_TRACE);
 
 	CmnTest_InitializeTestPlan(&plan);
 
@@ -45,6 +54,9 @@ int main(int argc, char **argv)
 	CmnTest_Run(&plan, True);
 
 	CmnTest_DestroyTest(&plan);
+
+	CmnLog_End();
+	CmnLog_EndCmnClibLog();
 
 	printf("### End test ###\n");
 


### PR DESCRIPTION
CommonLog再構築
・リファクタリング
・コード不使用（フリーフォーマット）でのログ出力を可能に
・cmn-clib内部用ログ出力機構を構築
・cmn-clibのSTART/ENDトレースログ出力を追加